### PR TITLE
Benchmarking wazero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM golang:1.21
 
 WORKDIR /app
 
-COPY . ./
-
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 
 RUN apt-get update
 RUN apt-get install gcc
+RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.30.0/tinygo_0.30.0_amd64.deb && dpkg -i tinygo_0.30.0_amd64.deb
+
+COPY . ./
+
 RUN go get
 RUN cp -r /usr/local/go/src/cmd/internal /usr/local/go/src/cmd/objfile
 RUN go build -buildmode=plugin -o plugin.so golangplugin/main.go
@@ -16,8 +18,8 @@ RUN go build -o ./hashicorpgoplugin ./hashicorp-go-plugin/main.go
 RUN go build -o ./pieplugin ./pie/main.go
 RUN go build -o ./pingoplugin ./pingo/main.go
 RUN go build -o ./plugplugin ./plug/plugin/main.go
+RUN tinygo build -o ./wazero.wasm -target wasi ./wazero/main.go
 RUN go list -export -f '{{if .Export}}packagefile {{.ImportPath}}={{.Export}}{{end}}' std `go list -f {{.Imports}} ./goloader/main.go | awk '{sub(/^\[/, ""); print }' | awk '{sub(/\]$/, ""); print }'` > importcfg
 RUN CGO_ENABLED=0 go tool compile -importcfg importcfg -o ./goloader.o ./goloader/main.go
 
 CMD ["go", "test", "-bench=."]
-

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-plugin v1.5.2
 	github.com/natefinch/pie v0.0.0-20170715172608-9a0d72014007
 	github.com/pkujhd/goloader v0.0.0-20230918021236-475614750c78
+	github.com/tetratelabs/wazero v1.5.0
 	github.com/traefik/yaegi v0.9.19
 	google.golang.org/protobuf v1.31.0
 )
@@ -21,6 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
 	golang.org/x/net v0.16.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,9 +66,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/traefik/yaegi v0.9.19 h1:ze01+pVtKmxSogy0wlAPSvm2LoDYuZj2LdH3S6GxHcQ=
 github.com/traefik/yaegi v0.9.19/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/wazero/main.go
+++ b/wazero/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"math/rand"
+)
+
+func main() {}
+
+//export RandInt
+func RandInt() int {
+	return rand.Int()
+}


### PR DESCRIPTION
This adds a benchmark for Wazero.

Now I am not sure if the comparison is 100% correct, because wasm is lower level, and would require some additional boilerplate to pass or receive arguments other than integers or floats (which btw is feasible via https://github.com/knqyf263/go-plugin, but it's using protocol buffers).

But I was interested in having a rough idea of the performance anyway.

I originally planned to compare it to [wasmer-go](https://github.com/wasmerio/wasmer-go), [wasmtime-go](https://github.com/bytecodealliance/wasmtime-go) and [wasmedge](https://github.com/uberswe/go-plugin-benchmark/issues/7), but I could not get those to work.

At the moment, the native go compiler only provides `//go:wasmimport` directives and no `//go:wasmexport`, which makes it unusable with `GOARCH=wasm` (hence the need for tinygo). But once it does in the future, it would be nice to have the same benchmark for both compilers.

Results on my computer (I did not update the readme because I am not sure what was the referential for the benchmark there):
```
goos: linux
goarch: amd64
pkg: github.com/uberswe/go-plugin-benchmark
cpu: AMD Ryzen 5 5600 6-Core Processor              
BenchmarkPluginRandInt/golang-plugin-12                                 171194259                7.103 ns/op
BenchmarkHashicorpGoPluginRandInt/hashicorp-go-plugin-12                   29697             40213 ns/op
BenchmarkPieRandInt/pie-12                                                 47438             25980 ns/op
BenchmarkPingoTcpRandInt/pingo-tcp-12                                      28970             38373 ns/op
BenchmarkPingoTcpRandInt/pingo-unix-12                                     39908             35372 ns/op
BenchmarkPlugRandInt/plug-12                                              128577              9531 ns/op
BenchmarkYaegiRandInt/yaegi-12                                           1000000              1021 ns/op
BenchmarkGoloaderRandInt/goloader-12                                    180961472                6.198 ns/op
BenchmarkWazeroRandInt/wazero-12                                        11387512                98.42 ns/op
```